### PR TITLE
Configure to use SQL for schema dumps, generate structure.sql

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,6 @@ module OmnivoreHotwireRails
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.active_record.schema_format = :sql
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,60 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying NOT NULL
+);
+
+
+--
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+SET search_path TO "$user", public;
+
+
+


### PR DESCRIPTION
Resolves #3 

Not much else needed to get going at this point, and need to move on to rspec install so I can get devving. 

Using `structure.sql` instead of `schema.rb` because it preserves state of db.
Possibly overkill (unlikely to need schema either way) but that's an argument in favor of this: might as well sidestep possible future costs/hassle of switching
- especially considering likelihood of complex constraints and other migrations in future, plus I expect to need to support jsonb with some complexity (current idea is to serialize menus there, pending decision to move them to separate model)
- Commits project to PG, which I'm fine with.